### PR TITLE
Save the modified print ticket from WSDA in the sample app

### DIFF
--- a/PrinterContextNativeRuntimeComponent/PrintHelper.cpp
+++ b/PrinterContextNativeRuntimeComponent/PrintHelper.cpp
@@ -188,7 +188,7 @@ namespace PrinterContextNativeRuntimeComponent
                     ComPtr<IPrintSchemaOption> option;
                     ThrowIf(options->GetAt(index, option.GetAddressOf()));
                     if (!option.Get()) ThrowIf(E_UNEXPECTED);
-                    ThrowIf(ticketFeature->get_SelectedOption(option.GetAddressOf()));
+                    ThrowIf(ticketFeature->put_SelectedOption(option.Get()));
                     if (!option.Get()) ThrowIf(E_UNEXPECTED);
                 }
             }


### PR DESCRIPTION
Issue:
We were not saving the modified print ticket from WSDA in the WorkflowAndWSDACombinedSampleApp.
Fix:
We need to call put_SelectedOption(...) instead of get_SelectedOption(...) as below.
ticketFeature->put_SelectedOption(option.Get());
in PrintHelperClass::SetFeatureOption(...)